### PR TITLE
bump versions in bower.json to work with 0.14

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,9 +18,9 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^4.1.0",
-    "purescript-effect": "^2.0.0",
-    "purescript-aff": "^5.1.1",
-    "purescript-aff-promise": "^2.1.0"
+    "purescript-prelude": "^5.0.0",
+    "purescript-effect": "^3.0.0",
+    "purescript-aff": "^6.0.0",
+    "purescript-aff-promise": "^3.0.0"
   }
 }


### PR DESCRIPTION
this builds and tests pass using `yarn jest —watch` as described in the README

this would allow purescript-jest to be added to latest package-set for purescript which in turn would allow purescript-html-parser-halogen to be submitted (which in turn would allow use of, for example, PrismJS, in purescript-cookbook recipes!)
